### PR TITLE
[#MISC-248] Add campaign signup origin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
-    crass (1.0.3)
+    crass (1.0.4)
     devise (4.4.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -160,7 +160,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.1.1)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -176,7 +176,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (4.8.0.341)
     nio4r (2.2.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     oj (2.18.5)
     oj_mimic_json (1.0.1)
@@ -220,8 +220,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     railties (5.1.4)
       actionpack (= 5.1.4)
       activesupport (= 5.1.4)
@@ -372,4 +372,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/app/admin/form.rb
+++ b/app/admin/form.rb
@@ -3,7 +3,7 @@
 ActiveAdmin.register Form do
   menu priority: 10
   permit_params :campaign_code, :name, :style, :title, :body, :redirect_url, :action, :success, :created_by_id,
-                :use_recaptcha, :recaptcha_key, :recaptcha_secret,
+                :use_recaptcha, :recaptcha_key, :recaptcha_secret, :origin,
                 form_fields_attributes: %i[id field_id label help required placeholder position _destroy]
 
   config.filters = false
@@ -58,6 +58,7 @@ ActiveAdmin.register Form do
       f.input :body, label: 'Body Text', input_html: { maxlength: 4096, rows: 3 }, hint: 'Allows HTML. Optional'
       f.input :action, label: 'Submit Button', input_html: { value: f.object.action || 'Subscribe' }
       f.input :redirect_url, label: 'Redirect url', hint: 'Upon successful submit, optionally redirect a user. ie. http://www.cru.org/success.'
+      f.input :origin, hint: 'Subscription origin. You must create another form if you want different origins on the same campaign.'
       f.input :success, label: 'Success Message',
                         input_html: { maxlength: 4096, rows: 3, value: f.object.success || Form::DEFAULT_SUCCESS },
                         hint: 'Allows HTML. Optional'

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -17,4 +17,14 @@ class Service < Adobe::Campaign::Service
   def self.active_admin_collection
     all.map { |service| service.values_at('label', 'name') }.sort {|a, b| a.first <=> b.first}.to_h
   end
+
+  def self.post_subscription(service_subs_url, person_pkey, origin = nil)
+    payload = {
+      'subscriber' => {
+        'PKey' => person_pkey
+      }
+    }
+    payload['origin'] = origin if origin.present?
+    post_request(service_subs_url, payload)
+  end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -15,6 +15,6 @@ class Service < Adobe::Campaign::Service
   end
 
   def self.active_admin_collection
-    all.map { |service| service.values_at('label', 'name') }.to_h
+    all.map { |service| service.values_at('label', 'name') }.sort {|a, b| a.first <=> b.first}.to_h
   end
 end

--- a/app/workers/adobe_campaign_worker.rb
+++ b/app/workers/adobe_campaign_worker.rb
@@ -48,7 +48,7 @@ class AdobeCampaignWorker
   def subscribe_to_adobe_campaign
     profile = find_or_create_adobe_profile
     service_subs_url = adobe_campaign_service['subscriptions']['href']
-    Adobe::Campaign::Service.post_subscription(service_subs_url, profile['PKey'])
+    Service.post_subscription(service_subs_url, profile['PKey'], form.origin)
   end
 
   def adobe_campaign_service

--- a/db/migrate/20180809152804_add_origin_to_form.rb
+++ b/db/migrate/20180809152804_add_origin_to_form.rb
@@ -1,0 +1,5 @@
+class AddOriginToForm < ActiveRecord::Migration[5.1]
+  def change
+    add_column :forms, :origin, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180222195941) do
+ActiveRecord::Schema.define(version: 20180809152804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 20180222195941) do
     t.boolean "use_recaptcha", default: false
     t.string "recaptcha_key"
     t.string "recaptcha_secret"
+    t.string "origin"
     t.index ["created_by_id"], name: "index_forms_on_created_by_id"
   end
 


### PR DESCRIPTION
- Sorts the dropdown lost of campaigns.
- Adds `origin` field to forms and passes it along when a subscription occurs (https://jira.cru.org/browse/MISC-248).
- Update vulnerable gems.