### PR TITLE
Add create_profile option to force ACS profile creation.

### DIFF
--- a/app/workers/adobe_campaign_worker.rb
+++ b/app/workers/adobe_campaign_worker.rb
@@ -29,7 +29,8 @@ class AdobeCampaignWorker
   end
 
   def find_or_create_adobe_profile
-    @adobe_profile ||= find_on_adobe_campaign
+    # First try to find the profile, unless we should always create one
+    @adobe_profile ||= find_on_adobe_campaign unless form.create_profile?
     @adobe_profile ||= post_to_adobe_campaign
   end
 

--- a/db/migrate/20190219191753_add_create_profile_field_to_forms.rb
+++ b/db/migrate/20190219191753_add_create_profile_field_to_forms.rb
@@ -1,0 +1,5 @@
+class AddCreateProfileFieldToForms < ActiveRecord::Migration[5.1]
+  def change
+    add_column :forms, :create_profile, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180831130300) do
+ActiveRecord::Schema.define(version: 20190219191753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 20180831130300) do
     t.string "recaptcha_key"
     t.string "recaptcha_secret"
     t.string "origin"
+    t.boolean "create_profile"
     t.index ["created_by_id"], name: "index_forms_on_created_by_id"
   end
 

--- a/spec/factories/form.rb
+++ b/spec/factories/form.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     association :created_by, factory: :user
     title { SecureRandom.alphanumeric(10) }
     body  { SecureRandom.alphanumeric(20) }
+    create_profile { false }
 
     factory :empty_form do
       initialize_with { new({}) }

--- a/spec/workers/adobe_campaign_worker_spec.rb
+++ b/spec/workers/adobe_campaign_worker_spec.rb
@@ -77,6 +77,26 @@ RSpec.describe AdobeCampaignWorker do
     end
   end
 
+  describe 'find_or_create_adobe_profile' do
+    it 'should skip \'find_on_adobe_campaign\' when \'form.create_profile?\' is set' do
+      form = create(:form, create_profile: true)
+      campaign_worker = AdobeCampaignWorker.new
+      campaign_worker.form = form
+      expect(campaign_worker).not_to receive(:find_on_adobe_campaign)
+      expect(campaign_worker).to receive(:post_to_adobe_campaign)
+      campaign_worker.find_or_create_adobe_profile
+    end
+
+    it 'should call \'find_on_adobe_campaign\' when \'form.create_profile?\' is not set' do
+      form = create(:form)
+      campaign_worker = AdobeCampaignWorker.new
+      campaign_worker.form = form
+      expect(campaign_worker).to receive(:find_on_adobe_campaign)
+      expect(campaign_worker).to receive(:post_to_adobe_campaign)
+      campaign_worker.find_or_create_adobe_profile
+    end
+  end
+
   describe 'post_to_adobe_campaign' do
     it 'should call Adobe::Campaign::Profile.post' do
       # Prepare


### PR DESCRIPTION
Adds a `create_profile` option to the form that forces Adobe Campaign profile creation instead of looking for an existing profile. This option is internal only for now and not exposed in the admin UI.