### PR TITLE
HS-1108616 - Move the GA4 event out of the Adobe Analytics check

### DIFF
--- a/public/campaign-form.js
+++ b/public/campaign-form.js
@@ -46,12 +46,12 @@ script3.onload = function () {
                     page: {pageInfo: {emailList: 'ACS | ' + data.campaign_codes.join(' | ')}}
                   })
                 window._satellite.track('aa-email-signup')
-
-                window.dataLayer = window.dataLayer || []
-                window.dataLayer.push({
-                  'event': 'ga-email-signup'
-                })
               }
+
+              window.dataLayer = window.dataLayer || []
+              window.dataLayer.push({
+                'event': 'ga-email-signup'
+              })
 
               // Call optional success callback if defined
               if (typeof campaignForm.successCallback === 'function') {


### PR DESCRIPTION
[HS ticket](https://secure.helpscout.net/conversation/2519010922/1108616/).

`window._satellite` is an Adobe Analytics thing, which has been (and is being) removed from our properties. We don't want to only send Google Analytics events if Adobe Analytics is defined.