### PR TITLE
Ensure JS runs after page load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 /.idea
 /.env.*
 /coverage
+
+# Ignore mac auto-generated files
+.DS_Store

--- a/public/campaign-form.js
+++ b/public/campaign-form.js
@@ -222,12 +222,14 @@ const scripts = ['https://ajax.googleapis.com/ajax/libs/jquery/3.7.0/jquery.min.
                  'https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.19.5/jquery.validate.min.js'];
 
 let promiseData = [];
-scripts.forEach((info) => {
-  promiseData.push(createScriptTag(info));
-});
+window.onload = () => {
+  scripts.forEach((info) => {
+    promiseData.push(createScriptTag(info));
+  });
 
-Promise.all(promiseData).then(() => {
-  postScriptLoad();
-}).catch((data) => {
-  console.warn(data + ' failed to load!');
-});
+  Promise.all(promiseData).then(() => {
+    postScriptLoad();
+  }).catch((data) => {
+    console.warn(data + ' failed to load!');
+  });
+}


### PR DESCRIPTION
Helpscout issue - https://secure.helpscout.net/conversation/2543499655/1122724?folderId=7296147

Certain pages have issues with new JS changes on campaign-forms.js, causing forms to send to 401 error pages.
The reason for this is due to the script running too fast and being called before the `document.body` is ready.

Due to the small size of the page on [adobe-campaign-form-test.html](https://stage.cru.org/us/en/adobe-campaign-form-test.html) we didn't pick this up. But with a larger page, like [her.bible](https://her.bible/blog/) the issue can be seen.

## Changes
I've wrapped the add scripts to the HTML code inside a `window.onload = () => {` function that will fire when the window is ready.

