### PR TITLE
Fix javascript sources/mime type error

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,4 +5,4 @@ import 'jquery-form'
 import 'jquery-validation'
 import '@activeadmin/activeadmin'
 
-import './custom/active_admin_custom'
+import 'active_admin_custom'

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,8 +5,10 @@ pin "application", preload: true
 
 # ActiveAdmin and dependencies
 pin "@activeadmin/activeadmin", to: "https://cdn.jsdelivr.net/npm/@activeadmin/activeadmin@2.13.1/app/assets/javascripts/active_admin/base.min.js"
-pin "jquery", to: "https://ga.jspm.io/npm:jquery@3.7.0/dist/jquery.js"
+pin "jquery", to: "https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.js"
 pin "jquery-ui", to: "https://cdn.jsdelivr.net/npm/jquery-ui@1.13.2/dist/jquery-ui.min.js"
 pin "jquery-ujs", to: "https://cdn.jsdelivr.net/npm/jquery-ujs@1.2.3/src/rails.min.js"
-pin "jquery-validation", to: "https://ga.jspm.io/npm:jquery-validation@1.19.5/dist/jquery.validate.js"
-pin "jquery-form", to: "https://ga.jspm.io/npm:jquery-form@4.3.0/dist/jquery.form.min.js"
+pin "jquery-validation", to: "https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.js"
+pin "jquery-form", to: "https://cdn.jsdelivr.net/npm/jquery-form@4.3.0/dist/jquery.form.min.js"
+
+pin "active_admin_custom", to: "custom/active_admin_custom.js"


### PR DESCRIPTION
Make sure that all JS dependencies are coming from the same source (there are minor differences between the different sources that might cause them to not get along well).

Also, need to include `active_admin_custom.js` in the importmaps.rb config file in order for it to get the correct mime type.

See https://secure.helpscout.net/conversation/2554090820/1128524?folderId=347597